### PR TITLE
Fix compatibility under windows

### DIFF
--- a/eazysvn.py
+++ b/eazysvn.py
@@ -485,6 +485,8 @@ def command(cmd, help_msg, alias=None):
         COMMANDS[cmd] = fn
         if alias:
             ALIASES[alias] = fn
+            if sys.platform == 'win32':
+                ALIASES[alias + '-script'] = fn
         fn.help_msg = help_msg
         fn.alias = alias
         return fn


### PR DESCRIPTION
When installing under windows using pip, it will create several files according 
to the `console_scripts` section:
- `{console_script}.exe`, for wrapping & executing python scripts
- `{console_script}-script.py`, the actual python script to be run

So, if you try to get the name from `sys.argv[0]`, it will give you 
`{console_script}-script`, which will not be handled in our ALIASES.
This patch is a workaround for that.
