### PR TITLE
Drop Python 2.7 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,13 +20,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "2.7"
           - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
-          - "pypy2.7"
           - "pypy3.7"
 
     steps:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,12 @@ Changelog
 =========
 
 
-1.15.2 (unreleased)
+1.16.0 (unreleased)
 -------------------
 
 - Add support for Python 3.8, 3.9, 3.10, and 3.11.
 
-- Drop support for Python 3.5 and 3.6.
+- Drop support for Python 2.7, 3.5 and 3.6.
 
 
 1.15.1 (2019-04-23)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
   matrix:
     # https://www.appveyor.com/docs/installed-software#python lists available
     # versions
-    - PYTHON: "C:\\Python27"
     - PYTHON: "C:\\Python37"
     - PYTHON: "C:\\Python38"
     - PYTHON: "C:\\Python39"

--- a/eazysvn.py
+++ b/eazysvn.py
@@ -14,8 +14,6 @@
 # or ezmerge as a shortcut for eazysvn switch/merge.
 #
 
-from __future__ import print_function
-
 import optparse
 import os
 import subprocess
@@ -24,7 +22,7 @@ from pipes import quote
 from xml.dom import minidom
 
 
-__version__ = '1.15.2.dev0'
+__version__ = '1.16.0.dev0'
 
 
 #

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -62,6 +61,7 @@ setup(
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Version Control',
     ],
+    python_requires=">=3.7",
 
     py_modules=['eazysvn'],
     zip_safe=False,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py37,py38,py39,py310,py311,pypy,pypy3
+    py37,py38,py39,py310,py311,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
The setup-python GitHub Action dropped Python 2.7 support: https://github.com/actions/setup-python/issues/672